### PR TITLE
Fix vim-racket ftplugin prevents vrod from loading

### DIFF
--- a/ftplugin/racket.vim
+++ b/ftplugin/racket.vim
@@ -2,10 +2,10 @@
 " Language:         Racket
 " Maintainer:       Micah Elliott
 
-if exists("b:did_ftplugin")
+if exists("b:did_ftplugin_vrod")
   finish
 endif
-let b:did_ftplugin = 1
+let b:did_ftplugin_vrod = 1
 
 
 " Enable completions


### PR DESCRIPTION
Both uses the `b:did_ftplugin` guard, and it causes vrod
to bail early if vim-racket ftplugin is loaded first.

The fix is to use `b:did_ftplugin_vrod` instead.

How to Repro:
============
1. Have both vim-racket and vrod in vimrc
1. Open a `foo.rkt` file
1. Type `:set keywordprg`

Bug:
====
* keywordprg is set to vim default `man -s`
* help doc path is not set by vrod
* `K` won't load from vrod's vim help doc

Expected:
=========
* keywordprg is set to vrod's `:help`
* `K` works as expected